### PR TITLE
Update recording's Youtube URLs

### DIFF
--- a/content/post/2021-04-08-monitoring-tools.md
+++ b/content/post/2021-04-08-monitoring-tools.md
@@ -15,7 +15,7 @@ Au programme, un retour d'expérience sur Thanos et un outil pour le monitoring 
 
 L'enregistrement du meetup a été possible grâce à l'aide de [Gérald](https://twitter.com/GeraldCrescione) de [driftctl](https://driftctl.com/) 🙏, il est disponible ici avec les timestamps/chapters :
 
-{{< youtube gNtl2aCeh7s >}}
+{{< youtube zblgkbmh22I >}}
 
 Pour les détails des présentations c'est par ici:
 

--- a/content/post/2021-07-26-summer-meetup.md
+++ b/content/post/2021-07-26-summer-meetup.md
@@ -21,7 +21,7 @@ Kubernetes
 
 L'enregistrement du meetup a été possible grâce à l'aide d'Emmanuel de [Mirakl](https://github.com/sre-paris/meetups/blob/main/meetups/%2310/mirakl-intro.pdf) 🙏, il est disponible ici avec les timestamps/chapters :
 
-{{< youtube nMZp15jrSmM >}}
+{{< youtube s_ARaVpzeAY >}}
 
 Pour les détails des présentations c'est par ici:
 

--- a/content/post/2021-10-07-rex-edition.md
+++ b/content/post/2021-10-07-rex-edition.md
@@ -21,7 +21,7 @@ Grafana.
 
 L'enregistrement du meetup a été possible grâce à l'aide d'Emmanuel de [Mirakl](https://www.mirakl.com/) 🙏, il est disponible ici avec les timestamps/chapters :
 
-{{< youtube PMS8kn3KTbA >}}
+{{< youtube Z7kVwUA6Dns >}}
 
 Pour les détails des présentations c'est par ici:
 

--- a/content/post/2022-05-24-live-from-bordeaux.md
+++ b/content/post/2022-05-24-live-from-bordeaux.md
@@ -21,7 +21,7 @@ des utilisateurs.
 
 L'enregistrement du meetup a été possible grâce à l'aide de Romain de [Mirakl](https://www.mirakl.com/) 🙏, il est disponible ici avec les timestamps/chapters :
 
-{{< youtube rrnCVoiALj0 >}}
+{{< youtube BfGcrBmuUyg >}}
 
 Pour les détails des présentations c'est par ici:
 

--- a/content/post/2022-08-01-live-from-lyon.md
+++ b/content/post/2022-08-01-live-from-lyon.md
@@ -16,7 +16,7 @@ Deux conférences ont ensuite été proposées: une vue générale des élément
 
 L'enregistrement du meetup est disponible ici avec les timestamps/chapters:
 
-{{< youtube agf3jSPoST4>}}
+{{< youtube 5GxEaOzIZ7I >}}
 
 Pour les détails des présentations c'est par ici: [https://github.com/sre-france/meetups/tree/main/meetups/2022-07-12](https://github.com/sre-france/meetups/tree/main/meetups/2022-07-12)
 


### PR DESCRIPTION
As meetup recordings were moved to a dedicated [SRE France Youtube](https://www.youtube.com/channel/UC02gfdwOcDsShPs6DRb7GNA/videos) account, this PR updates all the video IDs.